### PR TITLE
Refactor Facebook routes and fix page setup issue

### DIFF
--- a/models/services/common.js
+++ b/models/services/common.js
@@ -1,7 +1,7 @@
 // --------- Dependencies ---------
 var mongoose = require('mongoose');
 
-module.exports = function(UserSchema, messages, configuration) {
+module.exports = function(UserSchema, messages) {
   ['Facebook', 'YouTube'].forEach(function(serviceName) {
     /**
      * Populate service identifiers and tokens.

--- a/models/services/handlers.js
+++ b/models/services/handlers.js
@@ -4,6 +4,32 @@ var crypto = require('crypto');
 var config = require('../../config/settings');
 
 /**
+ * Processes the posts retrieved from a service.
+ * @param  {Object}   err             An error, if one has occurred
+ * @param  {Object[]} content         The content retrieved from the service
+ * @param  {Object}   updates         Progress details tracked by the caller
+ * @param  {number}   expectedLength  The number of posts expected
+ * @param  {Function} callback        The callback function to execute upon
+ *                                    completion
+ * @return {Object}                   The updated progress and list of posts
+ */
+module.exports.processContent = function(err, content, updates, expectedLength,
+    callback) {
+  // An error occurred
+  if (err) {
+    return callback(err);
+  }
+
+  // Retrieved content successfully
+  Array.prototype.push.apply(updates.posts, content);
+  updates.progress++;
+  if (updates.progress === expectedLength) {
+    callback(null, updates.posts);
+  }
+  return {progress: updates.progress, posts: updates.posts};
+};
+
+/**
  * Generates the app secret proof for authorizing Facebook API calls.
  * @param  {string} token The user's Facebook access token
  * @return {string}       A portion of the URL containing the app secret proof

--- a/models/services/handlers.js
+++ b/models/services/handlers.js
@@ -1,5 +1,20 @@
 // --------- Dependencies ---------
 var moment = require('moment');
+var crypto = require('crypto');
+var config = require('../../config/settings');
+
+/**
+ * Generates the app secret proof for authorizing Facebook API calls.
+ * @param  {string} token The user's Facebook access token
+ * @return {string}       A portion of the URL containing the app secret proof
+ *                        to attach to the full URL for the API call
+ */
+module.exports.generateAppSecretProof = function(token) {
+  return '&appsecret_proof=' + crypto
+    .createHmac('sha256', config.SERVICES.FACEBOOK.CLIENT_SECRET)
+    .update(token)
+    .digest('hex');
+};
 
 /**
  * Completes the refresh operation by saving the new content.

--- a/models/services/youtube.js
+++ b/models/services/youtube.js
@@ -296,8 +296,10 @@ module.exports = function(UserSchema, messages) {
 
     // Retrieve video posts
     calls.youtubeVideos = function(callback) {
-      var videoPosts = [];
-      var progress = 0;
+      var updates = {
+        progress: 0,
+        posts: []
+      };
       if (user.youtube.subscriptions.length > 0) {
         user.youtube.subscriptions.forEach(function(account) {
           var feedUrl = 'https://www.googleapis.com/youtube/v3/activities' +
@@ -308,17 +310,8 @@ module.exports = function(UserSchema, messages) {
 
           getYouTubeUploads(feedUrl, null, [], account.name,
             function(err, content) {
-              // An error occurred
-              if (err) {
-                return callback(err);
-              }
-
-              // Retrieved posts successfully
-              Array.prototype.push.apply(videoPosts, content);
-              progress++;
-              if (progress === user.youtube.subscriptions.length) {
-                callback(null, videoPosts);
-              }
+              updates = handlers.processContent(err, content, updates,
+                user.youtube.subscriptions.length, callback);
             });
         });
       } else {

--- a/models/user.js
+++ b/models/user.js
@@ -9,7 +9,6 @@ var PostCollectionSchema = PostCollection.schema;
 var passportLocalMongoose = require('passport-local-mongoose');
 var bcrypt = require('bcrypt');
 var crypto = require('crypto');
-var config = require('../config/settings');
 var messages = require('../config/messages');
 
 // --------- Account Constants ---------
@@ -441,8 +440,8 @@ UserSchema.statics.deleteUser = function(id, done) {
 /**
  * Set Up Services
  */
-require('./services/common')(UserSchema, messages, config);
-require('./services/facebook')(UserSchema, messages, config);
+require('./services/common')(UserSchema, messages);
+require('./services/facebook')(UserSchema, messages);
 require('./services/youtube')(UserSchema, messages);
 
 /**

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -59,7 +59,8 @@ module.exports = function(app, passport, isLoggedIn, nev) {
 
   app.post('/refresh/:service', isLoggedIn, function(req, res) {
     var serviceName = req.params.service;
-    var method = (serviceName === 'Facebook') ? 'Facebook' : 'YouTube';
+    var method = (serviceName.toLowerCase() === 'facebook') ? 'Facebook' :
+      'YouTube';
     req.user['refresh' + method](function(err, posts) {
       return handlers.handlePostRefresh(serviceName.toUpperCase(), err,
         '400-' + method, posts, req, res);

--- a/routes/services/facebook.js
+++ b/routes/services/facebook.js
@@ -8,8 +8,9 @@ module.exports = function(app, passport, isLoggedIn) {
   ['page', 'group'].forEach(function(type) {
     var plural = type + 's';
     var path = '/setup/facebook/' + plural;
+    var formatted = plural.charAt(0).toUpperCase() + plural.slice(1);
     app.get(path, isLoggedIn, function(req, res) {
-      User.setUpFacebookGroups(req.user._id, function(err, allContent,
+      User['setUpFacebook' + formatted](req.user._id, function(err, allContent,
           existingContent) {
         var settings = {name: 'Facebook', singular: type};
         handlers.retrieveActivity(settings, err, allContent, existingContent,

--- a/routes/services/handlers.js
+++ b/routes/services/handlers.js
@@ -91,7 +91,7 @@ var handlePostSetupError = module.exports.handlePostSetupError =
   };
 
 /**
- * [retrieveActivity description]
+ * Retrieves all new activity on the service.
  * @param  {Object}   settings        An object containing the service name and
  *                                    a singular term describing the content
  * @param  {Object}   err             An error, if one has occurred


### PR DESCRIPTION
- The Facebook page setup view was relying on the group method. Since
  we're generating the routes for all content types, we need to execute
  the correct method based on the type. This bug is fixed via this commit.